### PR TITLE
Add NetworkManagerClient.addAndActivateConnection()

### DIFF
--- a/lib/src/network_manager_client.dart
+++ b/lib/src/network_manager_client.dart
@@ -2477,6 +2477,28 @@ class NetworkManagerClient {
         object ?? _NetworkManagerObject(_bus, DBusObjectPath('/'), {}));
   }
 
+  /// Adds a new connection for [device] and activates it.
+  Future<NetworkManagerSettingsConnection> addAndActivateConnection(
+      {Map<String, Map<String, DBusValue>> connection = const {},
+      required NetworkManagerDevice device,
+      NetworkManagerAccessPoint? accessPoint}) async {
+    assert(device.wireless == null || accessPoint != null);
+    var result = await _manager!.callMethod(
+        _managerInterfaceName,
+        'AddAndActivateConnection',
+        [
+          DBusDict(
+              DBusSignature('s'),
+              DBusSignature('a{sv}'),
+              connection.map((key, value) =>
+                  MapEntry(DBusString(key), DBusDict.stringVariant(value)))),
+          device._object.path,
+          accessPoint?._object.path ?? DBusObjectPath('/'),
+        ],
+        replySignature: DBusSignature('oo'));
+    return _getConnection(result.returnValues[0] as DBusObjectPath)!;
+  }
+
   /// Activates a connection for [device].
   ///
   /// A specific [connection] may be specified, or else it is detected automatically.

--- a/lib/src/network_manager_client.dart
+++ b/lib/src/network_manager_client.dart
@@ -2478,7 +2478,12 @@ class NetworkManagerClient {
   }
 
   /// Adds a new connection for [device] and activates it.
-  Future<NetworkManagerSettingsConnection> addAndActivateConnection(
+  ///
+  /// Optionally, [connection] settings may be specified as a template. Missing
+  /// settings are automatically filled in.
+  ///
+  /// Note that when activating a wireless connection, the [accessPoint] must be specified.
+  Future<NetworkManagerActiveConnection> addAndActivateConnection(
       {Map<String, Map<String, DBusValue>> connection = const {},
       required NetworkManagerDevice device,
       NetworkManagerAccessPoint? accessPoint}) async {
@@ -2496,7 +2501,9 @@ class NetworkManagerClient {
           accessPoint?._object.path ?? DBusObjectPath('/'),
         ],
         replySignature: DBusSignature('oo'));
-    return _getConnection(result.returnValues[0] as DBusObjectPath)!;
+    var path = result.returnValues[1] as DBusObjectPath;
+    return activeConnectionAdded
+        .firstWhere((connection) => connection._object.path == path);
   }
 
   /// Activates a connection for [device].


### PR DESCRIPTION
This is perfect for the installer because:

> Adds a new connection using the given details (if any) as a template (automatically filling in missing settings with the capabilities of the given device and specific object), then activate the new connection.