### PR TITLE
Add NetworkManagerClient.state

### DIFF
--- a/example/connectivity.dart
+++ b/example/connectivity.dart
@@ -3,6 +3,7 @@ import 'package:nm/nm.dart';
 void main() async {
   var client = NetworkManagerClient();
   await client.connect();
+  print('Networking state is ${client.state}');
   client.propertiesChanged.listen((propertyNames) {
     print(propertyNames);
     if (propertyNames.contains('NetworkingEnabled') ||

--- a/lib/src/network_manager_client.dart
+++ b/lib/src/network_manager_client.dart
@@ -30,6 +30,39 @@ const _ip6ConfigInterfaceName = 'org.freedesktop.NetworkManager.IP6Config';
 const _dhcp6ConfigInterfaceName = 'org.freedesktop.NetworkManager.DHCP6Config';
 const _accessPointInterfaceName = 'org.freedesktop.NetworkManager.AccessPoint';
 
+/// Overall networking states.
+enum NetworkManagerState {
+  unknown,
+  asleep,
+  disconnected,
+  disconnecting,
+  connecting,
+  connectedLocal,
+  connectedSite,
+  connectedGlobal,
+}
+
+NetworkManagerState _decodeState(int value) {
+  switch (value) {
+    case 10:
+      return NetworkManagerState.asleep;
+    case 20:
+      return NetworkManagerState.disconnected;
+    case 30:
+      return NetworkManagerState.disconnecting;
+    case 40:
+      return NetworkManagerState.connecting;
+    case 50:
+      return NetworkManagerState.connectedLocal;
+    case 60:
+      return NetworkManagerState.connectedSite;
+    case 70:
+      return NetworkManagerState.connectedGlobal;
+    default:
+      return NetworkManagerState.unknown;
+  }
+}
+
 /// Internet connectivity states.
 enum NetworkManagerConnectivityState { unknown, none, portal, limited, full }
 
@@ -2454,6 +2487,13 @@ class NetworkManagerClient {
           'ConnectivityCheckUri',
         ) ??
         '';
+  }
+
+  /// The overall networking state.
+  NetworkManagerState get state {
+    var value =
+        _manager?.getUint32Property(_managerInterfaceName, 'State') ?? 0;
+    return _decodeState(value);
   }
 
   // FIXME: GlobalDnsConfiguration

--- a/test/nm_test.dart
+++ b/test/nm_test.dart
@@ -1153,6 +1153,23 @@ void main() {
     expect(client.version, equals('1.2.3'));
   });
 
+  test('state', () async {
+    var server = DBusServer();
+    addTearDown(() async => await server.close());
+    var clientAddress =
+        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+
+    var nm = MockNetworkManagerServer(clientAddress, state: 40);
+    addTearDown(() async => await nm.close());
+    await nm.start();
+
+    var client = NetworkManagerClient(bus: DBusClient(clientAddress));
+    addTearDown(() async => await client.close());
+    await client.connect();
+
+    expect(client.state, equals(NetworkManagerState.connecting));
+  });
+
   test('connectivity', () async {
     var server = DBusServer();
     addTearDown(() async => await server.close());


### PR DESCRIPTION
For being able to distinguish between site-wide and global connectivity.