### PR TITLE
Add Get/Set for GlobalDnsConfiguration

### DIFF
--- a/lib/src/network_manager_client.dart
+++ b/lib/src/network_manager_client.dart
@@ -2594,12 +2594,13 @@ class NetworkManagerClient {
     var searches = firstLevelDict['searches']?.asStringArray().toList() ?? [];
     var options = firstLevelDict['options']?.asStringArray().toList() ?? [];
     var domains = firstLevelDict['domains']
-            ?.asStringVariantDict()
+            ?.asDict()
             .map<String, DomainConfiguration>((key, value) {
           var config = value.asDict();
           var servers = config['servers']?.asStringArray().toList() ?? [];
           var options = config['options']?.asStringArray().toList() ?? [];
-          return MapEntry(key, DomainConfiguration(servers, options));
+          return MapEntry(
+              key.asString(), DomainConfiguration(servers, options));
         }) ??
         <String, DomainConfiguration>{};
     return GlobalDnsConfiguration(searches, options, domains);

--- a/lib/src/network_manager_client.dart
+++ b/lib/src/network_manager_client.dart
@@ -2244,11 +2244,15 @@ class _NetworkManagerObject extends DBusRemoteObject {
 /// [searches] is a list of search domains.
 /// [options] is a list of resolver options.
 /// [domains] is a map of [String] domain name associated to a [DomainConfiguration].
-class DnsConfiguration {
+class GlobalDnsConfiguration {
   final List<String> searches;
   final List<String> options;
   final Map<String, DomainConfiguration> domains;
-  DnsConfiguration(this.searches, this.options, this.domains);
+  GlobalDnsConfiguration(this.searches, this.options, this.domains);
+  const GlobalDnsConfiguration.empty()
+      : searches = const [],
+        options = const [],
+        domains = const {};
 }
 
 /// Configuration information of a specific domain.
@@ -2576,14 +2580,14 @@ class NetworkManagerClient {
   }
 
   /// Gets the GlobalDnsConfiguration
-  DnsConfiguration get globalDnsConfiguration {
+  GlobalDnsConfiguration get globalDnsConfiguration {
     var value = _manager?.getCachedProperty(
         _managerInterfaceName, 'GlobalDnsConfiguration');
     if (value == null) {
-      return DnsConfiguration([], [], {});
+      return GlobalDnsConfiguration([], [], {});
     }
     if (value.signature != DBusSignature('a{sv}')) {
-      return DnsConfiguration([], [], {});
+      return GlobalDnsConfiguration([], [], {});
     }
 
     var firstLevelDict = value.asStringVariantDict();
@@ -2598,11 +2602,12 @@ class NetworkManagerClient {
           return MapEntry(key, DomainConfiguration(servers, options));
         }) ??
         <String, DomainConfiguration>{};
-    return DnsConfiguration(searches, options, domains);
+    return GlobalDnsConfiguration(searches, options, domains);
   }
 
   /// Sets the GlobalDnsConfiguration
-  Future<void> setGlobalDnsConfiguration(DnsConfiguration configuration) async {
+  Future<void> setGlobalDnsConfiguration(
+      GlobalDnsConfiguration configuration) async {
     var dictionary = DBusDict.stringVariant({
       'searches': DBusArray.string(configuration.searches),
       'options': DBusArray.string(configuration.options),

--- a/lib/src/network_manager_client.dart
+++ b/lib/src/network_manager_client.dart
@@ -2239,6 +2239,11 @@ class _NetworkManagerObject extends DBusRemoteObject {
   }
 }
 
+/// Configuration information of multiple domains.
+///
+/// [searches] is a list of search domains.
+/// [options] is a list of resolver options.
+/// [domains] is a map of [String] domain name associated to a [DomainConfiguration].
 class DnsConfiguration {
   final List<String> searches;
   final List<String> options;
@@ -2246,6 +2251,10 @@ class DnsConfiguration {
   DnsConfiguration(this.searches, this.options, this.domains);
 }
 
+/// Configuration information of a specific domain.
+///
+/// [servers] is a list of DNS servers.
+/// [options] is a list of domain-specific options.
 class DomainConfiguration {
   final List<String> servers;
   final List<String> options;


### PR DESCRIPTION
This PR adds access to the `GlobalDnsConfiguration` property of `NetworkManager`.

It also adds 2 classes `DnsConfiguration` (to represent the 1st level of the dictionary) and `DomainConfiguration` (to represent each domain entry under the `domains` key) to simplify interacting with the returned object.